### PR TITLE
use app.kubernetes.io/name label

### DIFF
--- a/manifest/deployment.yaml
+++ b/manifest/deployment.yaml
@@ -4,15 +4,15 @@ metadata:
   name: configmapsecret-controller
   namespace: kube-system
   labels:
-    control-plane: configmapsecret-controller
+    app.kubernetes.io/name: configmapsecret-controller
 spec:
   selector:
     matchLabels:
-      control-plane: configmapsecret-controller
+      app.kubernetes.io/name: configmapsecret-controller
   template:
     metadata:
       labels:
-        control-plane: configmapsecret-controller
+        app.kubernetes.io/name: configmapsecret-controller
     spec:
       containers:
         - name: controller

--- a/manifest/service.yaml
+++ b/manifest/service.yaml
@@ -4,10 +4,10 @@ metadata:
   name: configmapsecret-controller
   namespace: kube-system
   labels:
-    control-plane: configmapsecret-controller
+    app.kubernetes.io/name: configmapsecret-controller
 spec:
   selector:
-    control-plane: configmapsecret-controller
+    app.kubernetes.io/name: configmapsecret-controller
   ports:
     - name: http-metrics
       port: 9091

--- a/manifest/serviceaccount.yaml
+++ b/manifest/serviceaccount.yaml
@@ -4,4 +4,4 @@ metadata:
   name: configmapsecret-controller
   namespace: kube-system
   labels:
-    control-plane: configmapsecret-controller
+    app.kubernetes.io/name: configmapsecret-controller


### PR DESCRIPTION
These changes replace the existing `control-plane` label key with `app.kubernetes.io/name`. The latter is [well-known](https://kubernetes.io/docs/reference/labels-annotations-taints/#app-kubernetes-io-name) and [recommended](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) which helps consistently query objects within the cluster.